### PR TITLE
Clear the itemsArray when the "Clear All" button event is fired

### DIFF
--- a/tab/js/scripts.js
+++ b/tab/js/scripts.js
@@ -31,4 +31,5 @@ button.addEventListener('click', function () {
   while (ul.firstChild) {
     ul.removeChild(ul.firstChild);
   }
+  itemsArray = [];
 });


### PR DESCRIPTION
I found that the itemsArray would write the old values to localStorage along with the new values after the localStorage was cleared and then updated.  Clearing the array when the "Clear All" button event is fired resolved the problem.